### PR TITLE
Add Option to Allow Shift Selecting Pawns on Name

### DIFF
--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -27,6 +27,8 @@
     <WorkTab.PlayCrunchTip>Play a crunchy sound when a pawn is assigned to a job they are not skilled at?</WorkTab.PlayCrunchTip>
     <WorkTab.DisableScrollwheel>Disable Scrollwheel</WorkTab.DisableScrollwheel>
     <WorkTab.DisableScrollwheelTip>Disable the scrollwheel functions (when hovering over skills)</WorkTab.DisableScrollwheelTip>
+    <WorkTab.DisableShiftOnRows>Shift+Click name should de/select pawn</WorkTab.DisableShiftOnRows>
+    <WorkTab.DisableShiftOnRowsTip>Shift+clicking on pawn names will select/unselect them, instead of incrementing/decrementing all their jobs at once.</WorkTab.DisableShiftOnRowsTip>
     <WorkTab.VerticalLabels>Vertical labels</WorkTab.VerticalLabels>
     <WorkTab.VerticalLabelsTip>Display work labels vertically</WorkTab.VerticalLabelsTip>
     <WorkTab.FontFix>Fix vertical fonts</WorkTab.FontFix>

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -10,6 +10,7 @@ namespace WorkTab
     {
         public static  int    defaultPriority = 3;
         public static  bool   disableScrollwheel;
+        public static  bool   disableShiftOnRows;
         public static  int    maxPriority            = 9;
         public static  bool   playCrunch             = true;
         public static  bool   playSounds             = true;
@@ -57,6 +58,8 @@ namespace WorkTab
                                      "WorkTab.PlayCrunchTip".Translate() );
             options.CheckboxLabeled( "WorkTab.DisableScrollwheel".Translate(), ref disableScrollwheel,
                                      "WorkTab.DisableScrollwheelTip".Translate() );
+            options.CheckboxLabeled( "WorkTab.DisableShiftOnRows".Translate(), ref disableShiftOnRows,
+                                     "WorkTab.DisableShiftOnRowsTip".Translate() );
             var verticalLabelsBuffer = verticalLabels;
             options.CheckboxLabeled( "WorkTab.VerticalLabels".Translate(), ref verticalLabelsBuffer,
                                      "WorkTab.VerticalLabelsTip".Translate() );
@@ -92,6 +95,7 @@ namespace WorkTab
             Scribe_Values.Look( ref playSounds, "PlaySounds", true );
             Scribe_Values.Look( ref playCrunch, "PlayCrunch", true );
             Scribe_Values.Look( ref disableScrollwheel, "DisableScrollwheel" );
+            Scribe_Values.Look( ref disableShiftOnRows, "DisableShiftOnRows" );
             Scribe_Values.Look( ref verticalLabels, "VerticalLabels", true );
             Scribe_Values.Look( ref _fontFix, "FontFix", true );
 

--- a/Source/PawnColumns/PawnColumnWorker_WorkTabLabel.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkTabLabel.cs
@@ -62,7 +62,7 @@ namespace WorkTab
         public override void DoCell( Rect rect, Pawn pawn, PawnTable table )
         {
             // intercept interactions before base has a chance to act on them
-            if ( Shift && Mouse.IsOver( rect ) )
+            if ( !Settings.disableShiftOnRows && Shift && Mouse.IsOver( rect ) )
             {
                 if ( RightClicked( rect ) || ScrolledUp( rect ) )
                 {


### PR DESCRIPTION
## Add Option to Allow Shift Selecting Pawns on Name

![20201128031401_1](https://user-images.githubusercontent.com/7416299/100497265-33a77f00-3128-11eb-9ffe-a5891d1ade8a.jpg)

Add a new option (default Off, preserve existing behavior), where, if new option is enabled, Shift+Click on pawn names will select/deselect them, instead of incrementing/decrementing all the cells in their row.

I have lots of use cases where I want to, for example, select all my Growers or Miners at once. My reflex is to go to Work Tab, sort by that WorkType, bubble the skilled pawns to the top, click one, and then try to shift+click more to keep selecting them, but default behavior starts incrementing/decrementing everything in their row.

This gives an option to let users shift+click and select multiple pawns from the Work Tab.