### PR TITLE
Allow pawns to have no non-emergency jobs enabled.

### DIFF
--- a/Source/HarmonyPatches/Worksettings/Pawn_WorkSettings_CacheWorkGiversInOrder.cs
+++ b/Source/HarmonyPatches/Worksettings/Pawn_WorkSettings_CacheWorkGiversInOrder.cs
@@ -59,7 +59,7 @@ namespace WorkTab
                 // lowest priority non-emergency job
                 var maxEmergPrio = allWorkgivers
                                   .Where( wg => !wg.def.emergency )
-                                  .Min( wg => pawn.GetPriority( wg.def, -1 ) );
+                                  .Min( wg => (int?)pawn.GetPriority( wg.def, -1 ) ) ?? 0;
 
                 // create lists of workgivers
                 normalWorkgivers = allWorkgivers


### PR DESCRIPTION
I was testing my Misc Robots WorkTab and I found that if you disable all the non-emergency jobs, this error throws. I presume the 0 is correct, though it may need to be int.MaxValue depending on your intentions.

1.3 has the same error and needs the same change.