### PR TITLE
Fix horizontal scroll area

### DIFF
--- a/Source/Extensions/PawnTable_Extensions.cs
+++ b/Source/Extensions/PawnTable_Extensions.cs
@@ -1,0 +1,35 @@
+﻿using RimWorld;
+using RimWorld.BaseGen;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace WorkTab.Extensions {
+    internal static class PawnTable_Extensions {
+        private static ConditionalWeakTable<PawnTable, StrongBox<Rect>> outRectDictionary=new ConditionalWeakTable<PawnTable, StrongBox<Rect>>();
+        /// <summary>
+        /// Sets the rectangle the <see cref="PawnTable"/> is drawn in.
+        /// </summary>
+        /// <param name="pawnTable">The <see cref="PawnTable"/> being extended.</param>
+        /// <param name="outRect">The rectangle the <see cref="PawnTable"/> will be drawn in.</param>
+        internal static void set_OutRect(this PawnTable pawnTable, Rect outRect) {
+            var value = outRectDictionary.GetValue(
+                pawnTable,
+                a => new StrongBox<Rect>(outRect)
+            );
+            value.Value = outRect;
+        }
+        /// <summary>
+        /// Gets the rectangle the <see cref="PawnTable"/> will be drawn in.
+        /// </summary>
+        /// <param name="pawnTable">The <see cref="PawnTable"/> being extended.</param>
+        /// <returns>The rectangle the <see cref="PawnTable"/> will be drawn in.</returns>
+        internal static Rect get_OutRect(this PawnTable pawnTable) {
+            return outRectDictionary.GetOrCreateValue(pawnTable).Value;
+        }
+    }
+}

--- a/Source/HarmonyPatches/PawnTable/PawnTable_PawnTableOnGUI.cs
+++ b/Source/HarmonyPatches/PawnTable/PawnTable_PawnTableOnGUI.cs
@@ -8,6 +8,7 @@ using HarmonyLib;
 using RimWorld;
 using UnityEngine;
 using Verse;
+using WorkTab.Extensions;
 
 namespace WorkTab {
     [HarmonyPatch(typeof(PawnTable), nameof(PawnTable.PawnTableOnGUI))]
@@ -79,7 +80,11 @@ namespace WorkTab {
             // Instead, we want to limit outRect to the available view area, so a horizontal scrollbar can appear.
             float labelWidth = cachedColumnWidths[0];
             var labelCol   = columns[0];
-            float outWidth   = Mathf.Min( cachedSize.x - labelWidth, UI.screenWidth - (standardWindowMargin * 2f) );
+            // ideally this method would be called with a Rect outRect
+            // indicating the window it is being drawn in instead
+            // of a Vector2 position
+            var outRect = __instance.get_OutRect();
+            float outWidth   = outRect.width - labelWidth;
             float viewWidth  = cachedSize.x - labelWidth - 16f;
 
             Rect labelHeaderRect = new Rect(

--- a/Source/PawnTable/MainTabWindow_WorkTab.cs
+++ b/Source/PawnTable/MainTabWindow_WorkTab.cs
@@ -10,6 +10,7 @@ using RimWorld;
 using RimWorld.Planet;
 using UnityEngine;
 using Verse;
+using WorkTab.Extensions;
 using static WorkTab.Constants;
 using static WorkTab.InteractionUtilities;
 using static WorkTab.Resources;
@@ -122,6 +123,7 @@ namespace WorkTab {
         }
 
         public override void DoWindowContents(Rect rect) {
+            Instance.Table.set_OutRect(rect);
             if (_columnsChanged) {
                 RebuildTable();
             }


### PR DESCRIPTION
fixes #157, #159 and #164

The scroll area was using cachedSize for its output rectangle capping it at the screen width. As the "Work"-tab window is not always as wide as the screen, ouput rectangle was too wide when there were many work types.

To fix this the PawnTable was extended with the property methods 

- void set_OutRect(this PawnTable, Rect)
- Rect get_OutRect() 

'fake adding' a new property that can be used to set and get the "Work"-tab window dimension instead of relying on the screen size.

MainTabWindow_WorkTab.DoWindowContents calls set_OutRect with the window dimension 
```csharp
public override void DoWindowContents(Rect rect) {
    Instance.Table.set_OutRect(rect);
    ...
}
```
and PawnTable_PawnTableOnGUI.PawnTableOnGUI calls get_OutRect to clamp the output rectangle properly
```csharp
public static bool Prefix(PawnTable __instance,
                                   Vector2 position,
                                   PawnTableDef ___def,
                                   ref Vector2 ___scrollPosition)
//harmony 1.2.0.1 gives access to private fields by ___name.
{
    ...
    var outRect = __instance.get_OutRect();
    float outWidth   = outRect.width - labelWidth;
    ...
}
```
I think ideally PawnTable.PawnTableOnGUI's parameter would be Rect window instead of Vector2 position in the future.