### PR TITLE
Add Setting to Render Job Column as Text (instead of Icon)

### DIFF
--- a/Defs/PawnColumnDefs.xml
+++ b/Defs/PawnColumnDefs.xml
@@ -20,6 +20,14 @@
   </PawnColumnDef>
 
   <PawnColumnDef>
+    <defName>JobText</defName>
+    <workerClass>WorkTab.PawnColumnWorker_JobText</workerClass>
+    <sortable>true</sortable>
+    <label>Current job</label>
+    <headerTip>Current job</headerTip>    
+  </PawnColumnDef>
+
+  <PawnColumnDef>
     <defName>CopyPasteDetailedWorkPriorities</defName>
     <workerClass>WorkTab.PawnColumnWorker_CopyPasteDetailedWorkPriorities</workerClass>
   </PawnColumnDef>

--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -27,6 +27,8 @@
     <WorkTab.PlayCrunchTip>Play a crunchy sound when a pawn is assigned to a job they are not skilled at?</WorkTab.PlayCrunchTip>
     <WorkTab.DisableScrollwheel>Disable Scrollwheel</WorkTab.DisableScrollwheel>
     <WorkTab.DisableScrollwheelTip>Disable the scrollwheel functions (when hovering over skills)</WorkTab.DisableScrollwheelTip>
+    <WorkTab.JobTextMode>Current job column as text (requires restart)</WorkTab.JobTextMode>
+    <WorkTab.JobTextModeTip>Render the current job column as a text column with the whole job, instead of just an icon.\n\n(Due to a technical limitation, you must restart the game after enabling this option.)</WorkTab.JobTextModeTip>
     <WorkTab.VerticalLabels>Vertical labels</WorkTab.VerticalLabels>
     <WorkTab.VerticalLabelsTip>Display work labels vertically</WorkTab.VerticalLabelsTip>
     <WorkTab.FontFix>Fix vertical fonts</WorkTab.FontFix>

--- a/Source/Core/Constants.cs
+++ b/Source/Core/Constants.cs
@@ -12,6 +12,7 @@ namespace WorkTab {
         public const           float                      MinTimeBarLabelSpacing  = 50f;
         public const           int                        TimeBarHeight           = 40;
         public const           int                        VerticalHeaderHeight    = 100;
+        public const           int                        JobTextWidth            = 150;
         public const           int                        WorkGiverBoxSize        = 20;
         public const           int                        WorkGiverWidth          = 25;
         public const           int                        WorkTypeBoxSize         = 25;

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -8,6 +8,7 @@ namespace WorkTab {
     public class Settings: ModSettings {
         public static  int    defaultPriority = 3;
         public static  bool   disableScrollwheel;
+        public static  bool   jobTextMode            = false;
         public static  int    maxPriority            = 9;
         public static  bool   playCrunch             = true;
         public static  bool   playSounds             = true;
@@ -51,6 +52,8 @@ namespace WorkTab {
                                      "WorkTab.PlayCrunchTip".Translate());
             options.CheckboxLabeled("WorkTab.DisableScrollwheel".Translate(), ref disableScrollwheel,
                                      "WorkTab.DisableScrollwheelTip".Translate());
+            options.CheckboxLabeled("WorkTab.JobTextMode".Translate(), ref jobTextMode,
+                                     "WorkTab.JobTextModeTip".Translate());
             bool verticalLabelsBuffer = verticalLabels;
             options.CheckboxLabeled("WorkTab.VerticalLabels".Translate(), ref verticalLabelsBuffer,
                                      "WorkTab.VerticalLabelsTip".Translate());
@@ -86,6 +89,7 @@ namespace WorkTab {
             Scribe_Values.Look(ref playSounds, "PlaySounds", true);
             Scribe_Values.Look(ref playCrunch, "PlayCrunch", true);
             Scribe_Values.Look(ref disableScrollwheel, "DisableScrollwheel");
+            Scribe_Values.Look(ref jobTextMode, "JobTextMode");
             Scribe_Values.Look(ref verticalLabels, "VerticalLabels", true);
             Scribe_Values.Look(ref _fontFix, "FontFix", true);
 

--- a/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
+++ b/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
@@ -24,7 +24,7 @@ namespace WorkTab {
             // insert mood and job columns before first work column name
             int firstWorkindex =
                 workTable.columns.FindIndex(d => d.workerClass == typeof(PawnColumnWorker_WorkPriority));
-            if (true) {
+            if (Settings.jobTextMode) {
                 workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.JobText);
             } else {
                 workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.Job);

--- a/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
+++ b/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
@@ -24,7 +24,11 @@ namespace WorkTab {
             // insert mood and job columns before first work column name
             int firstWorkindex =
                 workTable.columns.FindIndex(d => d.workerClass == typeof(PawnColumnWorker_WorkPriority));
-            workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.Job);
+            if (true) {
+                workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.JobText);
+            } else {
+                workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.Job);
+            }
             workTable.columns.Insert(firstWorkindex + 1, PawnColumnDefOf.Mood);
 
             // go over PawnColumnDefs and replace all PawnColumnWorker_WorkPriority

--- a/Source/PawnColumns/PawnColumnWorker_JobText.cs
+++ b/Source/PawnColumns/PawnColumnWorker_JobText.cs
@@ -1,0 +1,33 @@
+// Copyright Karel Kroeze, 2020-2021.
+// WorkTab/WorkTab/PawnColumnWorker_WorkTabLabel.cs
+
+using RimWorld;
+using Verse;
+using static WorkTab.Constants;
+
+namespace WorkTab {
+    public class PawnColumnWorker_JobText : PawnColumnWorker_Text {
+        public override int GetMinWidth(PawnTable table)
+        {
+            return JobTextWidth;
+        }
+        private string GetJobString(Pawn pawn)
+        {
+            return pawn.jobs?.curDriver?.GetReport() ?? "";
+        }
+        protected override string GetTextFor(Pawn pawn) {
+            return GetJobString(pawn);
+        }
+        protected override string GetTip(Pawn pawn) {
+            return GetJobString(pawn);
+        }
+        public string GetValueToCompare(Pawn pawn)
+        {
+            return GetJobString(pawn);
+        }
+        public override int Compare(Pawn a, Pawn b)
+        {
+            return GetValueToCompare(a).CompareTo(GetValueToCompare(b));
+        }
+    }
+}

--- a/Source/Utilities/DefOf.cs
+++ b/Source/Utilities/DefOf.cs
@@ -14,6 +14,7 @@ namespace WorkTab {
         [MayRequireIdeology] public static PawnColumnDef Guest;
         [MayRequireIdeology] public static PawnColumnDef Ideo;
         public static                      PawnColumnDef Job;
+        public static                      PawnColumnDef JobText;
         public static                      PawnColumnDef LabelShortWithIcon;
         public static                      PawnColumnDef Mood;
         public static                      PawnColumnDef WorkTabLabel;


### PR DESCRIPTION
Add Setting to Render Job Column as Text (instead of Icon)

![20230210185414_1](https://user-images.githubusercontent.com/7416299/218224040-e9a646cb-e1ea-4307-a5a9-de4d44d137e6.jpg)

![20230210185417_1](https://user-images.githubusercontent.com/7416299/218224047-41661693-0480-4749-995e-1aed93f514e0.jpg)

![20230210185310_1](https://user-images.githubusercontent.com/7416299/218224051-8ec44707-8a83-4cc0-a8f1-cc0b08fd6d65.jpg)
