### PR TITLE
Fix: Priorities reset after save-load.

### DIFF
--- a/Defs/PawnColumnDefs.xml
+++ b/Defs/PawnColumnDefs.xml
@@ -20,6 +20,14 @@
   </PawnColumnDef>
 
   <PawnColumnDef>
+    <defName>JobText</defName>
+    <workerClass>WorkTab.PawnColumnWorker_JobText</workerClass>
+    <sortable>true</sortable>
+    <label>Current job</label>
+    <headerTip>Current job</headerTip>    
+  </PawnColumnDef>
+
+  <PawnColumnDef>
     <defName>CopyPasteDetailedWorkPriorities</defName>
     <workerClass>WorkTab.PawnColumnWorker_CopyPasteDetailedWorkPriorities</workerClass>
   </PawnColumnDef>

--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -27,6 +27,8 @@
     <WorkTab.PlayCrunchTip>Play a crunchy sound when a pawn is assigned to a job they are not skilled at?</WorkTab.PlayCrunchTip>
     <WorkTab.DisableScrollwheel>Disable Scrollwheel</WorkTab.DisableScrollwheel>
     <WorkTab.DisableScrollwheelTip>Disable the scrollwheel functions (when hovering over skills)</WorkTab.DisableScrollwheelTip>
+    <WorkTab.HighlightActiveWorkCells>Highlight Active Work Cells</WorkTab.HighlightActiveWorkCells>
+    <WorkTab.HighlightActiveWorkCellsTip>Highlight the grid squares in the work tab when the pawn is actually working that job right now.</WorkTab.HighlightActiveWorkCellsTip>
     <WorkTab.VerticalLabels>Vertical labels</WorkTab.VerticalLabels>
     <WorkTab.VerticalLabelsTip>Display work labels vertically</WorkTab.VerticalLabelsTip>
     <WorkTab.FontFix>Fix vertical fonts</WorkTab.FontFix>

--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -11,7 +11,7 @@
     <WorkTab.CollapseAll>Click to collapse all priorities\nCtrl-click headers to toggle expanding individual priorities</WorkTab.CollapseAll>
 
     <!-- column header tooltips -->
-    <WorkTab.DetailedColumnTip>Shift + left-click or scroll up to increase priorities\nShift + right click or scroll down to decrease priorities</WorkTab.DetailedColumnTip>
+    <WorkTab.DetailedColumnTip>Shift + left-click or scroll up to raise priorities\nShift + right click or scroll down to lower priorities</WorkTab.DetailedColumnTip>
     <WorkTab.ToggleColumnTip>Shift + left-click or scroll up to toggle priorities on\nShift + right click or scroll down to toggle priorities off</WorkTab.ToggleColumnTip>
     <WorkTab.ExpandWorkgiversColumnTip>Ctrl + click to expand list of detailed priorities</WorkTab.ExpandWorkgiversColumnTip>
     <WorkTab.CollapseWorkgiversColumnTip>Ctrl + click to collapse list of detailed priorities</WorkTab.CollapseWorkgiversColumnTip>
@@ -54,7 +54,7 @@
     <WorkTab.XIsAssignedToY>{0} is assigned to {1}</WorkTab.XIsAssignedToY>
 
     <!-- pawn label tooltip  -->
-    <WorkTab.LabelCellTip>Click to jump to\nShift-left-click or scroll up to increment priorities\nShift-right-click or scroll down to decrement priorities</WorkTab.LabelCellTip>
+    <WorkTab.LabelCellTip>Click to jump to\nShift-left-click or scroll up to raise priorities\nShift-right-click or scroll down to lower priorities</WorkTab.LabelCellTip>
 
     <!-- Favourites -->
     <Fluffy.WorkTab.CreateFavourite>Create new favourite</Fluffy.WorkTab.CreateFavourite>

--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -21,6 +21,8 @@
     <WorkTab.24HourModeTip>Should times be shown in 12h (e.g. noon, 9p.m.) or 24h (e.g. 12:00, 21:00) mode?</WorkTab.24HourModeTip>
     <WorkTab.MaxPriority>Levels of priority</WorkTab.MaxPriority>
     <WorkTab.MaxPriorityTip>How many levels of priority should we use? (Limited to between 4 and 9)</WorkTab.MaxPriorityTip>
+    <WorkTab.DefaultPriority>Default priority</WorkTab.DefaultPriority>
+    <WorkTab.DefaultPriorityTip>Which level of priority is assigned by default?</WorkTab.DefaultPriorityTip>
     <WorkTab.PlaySounds>Sounds</WorkTab.PlaySounds>
     <WorkTab.PlaySoundsTip>Play sounds when a priority is changed?</WorkTab.PlaySoundsTip>
     <WorkTab.PlayCrunch>Crunchy sounds</WorkTab.PlayCrunch>

--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -27,6 +27,8 @@
     <WorkTab.PlayCrunchTip>Play a crunchy sound when a pawn is assigned to a job they are not skilled at?</WorkTab.PlayCrunchTip>
     <WorkTab.DisableScrollwheel>Disable Scrollwheel</WorkTab.DisableScrollwheel>
     <WorkTab.DisableScrollwheelTip>Disable the scrollwheel functions (when hovering over skills)</WorkTab.DisableScrollwheelTip>
+    <WorkTab.JobTextMode>Current job column as text (requires restart)</WorkTab.JobTextMode>
+    <WorkTab.JobTextModeTip>Render the current job column as a text column with the whole job, instead of just an icon.\n\n(Due to a technical limitation, you must restart the game after enabling this option.)</WorkTab.JobTextModeTip>
     <WorkTab.VerticalLabels>Vertical labels</WorkTab.VerticalLabels>
     <WorkTab.VerticalLabelsTip>Display work labels vertically</WorkTab.VerticalLabelsTip>
     <WorkTab.FontFix>Fix vertical fonts</WorkTab.FontFix>

--- a/Languages/English/Keyed/Keyed-English.xml
+++ b/Languages/English/Keyed/Keyed-English.xml
@@ -30,9 +30,9 @@
     <WorkTab.DisableScrollwheel>Disable Scrollwheel</WorkTab.DisableScrollwheel>
     <WorkTab.DisableScrollwheelTip>Disable the scrollwheel functions (when hovering over skills)</WorkTab.DisableScrollwheelTip>
     <WorkTab.JobTextMode>Current job column as text (requires restart)</WorkTab.JobTextMode>
-    <WorkTab.JobTextModeTip>Render the current job column as a text column with the whole job, instead of just an icon.\n\n(Due to a technical limitation, you must restart the game after enabling this option.)</WorkTab.JobTextModeTip>
-    <WorkTab.HighlightActiveWorkCells>Highlight Active Work Cells</WorkTab.HighlightActiveWorkCells>
-    <WorkTab.HighlightActiveWorkCellsTip>Highlight the grid squares in the work tab when the pawn is actually working that job right now.</WorkTab.HighlightActiveWorkCellsTip>
+    <WorkTab.JobTextModeTip>Render the current job column as a text description of current activity.\nWhen disabled, an icon is displayed.\n\n(Due to a technical limitation, you must restart the game after changing this option.)</WorkTab.JobTextModeTip>
+    <WorkTab.HighlightCurrentJobCell>Highlight current job cell</WorkTab.HighlightCurrentJobCell>
+    <WorkTab.HighlightCurrentJobCellTip>Highlight the grid square in the work tab when the pawn is actually working that job right now.</WorkTab.HighlightCurrentJobCellTip>
     <WorkTab.VerticalLabels>Vertical labels</WorkTab.VerticalLabels>
     <WorkTab.VerticalLabelsTip>Display work labels vertically</WorkTab.VerticalLabelsTip>
     <WorkTab.FontFix>Fix vertical fonts</WorkTab.FontFix>

--- a/Source/Core/Constants.cs
+++ b/Source/Core/Constants.cs
@@ -12,6 +12,7 @@ namespace WorkTab {
         public const           float                      MinTimeBarLabelSpacing  = 50f;
         public const           int                        TimeBarHeight           = 40;
         public const           int                        VerticalHeaderHeight    = 100;
+        public const           int                        JobTextWidth            = 150;
         public const           int                        WorkGiverBoxSize        = 20;
         public const           int                        WorkGiverWidth          = 25;
         public const           int                        WorkTypeBoxSize         = 25;

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -8,6 +8,7 @@ namespace WorkTab {
     public class Settings: ModSettings {
         public static  int    defaultPriority = 3;
         public static  bool   disableScrollwheel;
+        public static  bool   jobTextMode            = false;
         public static  int    maxPriority            = 9;
         public static  bool   playCrunch             = true;
         public static  bool   playSounds             = true;
@@ -51,6 +52,8 @@ namespace WorkTab {
                                      "WorkTab.PlayCrunchTip".Translate());
             options.CheckboxLabeled("WorkTab.DisableScrollwheel".Translate(), ref disableScrollwheel,
                                      "WorkTab.DisableScrollwheelTip".Translate());
+            options.CheckboxLabeled("WorkTab.JobTextMode".Translate(), ref jobTextMode,
+                                     "WorkTab.JobTextModeTip".Translate());
             bool verticalLabelsBuffer = verticalLabels;
             options.CheckboxLabeled("WorkTab.VerticalLabels".Translate(), ref verticalLabelsBuffer,
                                      "WorkTab.VerticalLabelsTip".Translate());
@@ -86,6 +89,7 @@ namespace WorkTab {
             Scribe_Values.Look(ref playSounds, "PlaySounds", true);
             Scribe_Values.Look(ref playCrunch, "PlayCrunch", true);
             Scribe_Values.Look(ref disableScrollwheel, "DisableScrollwheel");
+            Scribe_Values.Look(ref jobTextMode, "JobTextMode");
             Scribe_Values.Look(ref verticalLabels, "VerticalLabels", true);
             Scribe_Values.Look(ref _fontFix, "FontFix", true);
 

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -15,13 +15,8 @@ namespace WorkTab {
         public static bool jobTextMode             = false;
         public static bool highlightCurrentJobCell = true;
         public static bool verticalLabels          = true;
-        private static string _defaultPriorityBuffer = defaultPriority.ToString();
-
-        // public static bool sharedFavourites = true;
         private static bool _fontFix = true;
-
-        // buffers
-        private static string _maxPriorityBuffer = maxPriority.ToString();
+        // public static bool sharedFavourites = true;
 
         public Settings() {
             ApplyFontFix(_fontFix);
@@ -39,10 +34,12 @@ namespace WorkTab {
         public static void DoWindowContents(Rect rect) {
             Listing_Standard options = new Listing_Standard();
             options.Begin(rect);
-            options.TextFieldNumericLabeled("WorkTab.MaxPriority".Translate(), ref maxPriority, ref _maxPriorityBuffer,
+            string maxPriorityBuffer = null;
+            options.TextFieldNumericLabeled("WorkTab.MaxPriority".Translate(), ref maxPriority, ref maxPriorityBuffer,
                                              4, 9, "WorkTab.MaxPriorityTip".Translate(), 1 / 8f);
+            string defaultPriorityBuffer = null;
             options.TextFieldNumericLabeled("WorkTab.DefaultPriority".Translate(), ref defaultPriority,
-                                             ref _defaultPriorityBuffer, 1, 9, "WorkTab.DefaultPriorityTip".Translate(),
+                                             ref defaultPriorityBuffer, 1, 9, "WorkTab.DefaultPriorityTip".Translate(),
                                              1 / 8f);
             options.CheckboxLabeled("WorkTab.24HourMode".Translate(), ref TwentyFourHourMode,
                                      "WorkTab.24HourModeTip".Translate());

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -13,6 +13,7 @@ namespace WorkTab {
         public static  bool   playSounds             = true;
         public static  bool   TwentyFourHourMode     = true;
         public static  bool   verticalLabels         = true;
+        public static  bool   highlightActiveWorkCells;
         private static string _defaultPriorityBuffer = defaultPriority.ToString();
 
         // public static bool sharedFavourites = true;
@@ -51,6 +52,8 @@ namespace WorkTab {
                                      "WorkTab.PlayCrunchTip".Translate());
             options.CheckboxLabeled("WorkTab.DisableScrollwheel".Translate(), ref disableScrollwheel,
                                      "WorkTab.DisableScrollwheelTip".Translate());
+            options.CheckboxLabeled("WorkTab.HighlightActiveWorkCells".Translate(), ref highlightActiveWorkCells,
+                                     "WorkTab.HighlightActiveWorkCellsTip".Translate());
             bool verticalLabelsBuffer = verticalLabels;
             options.CheckboxLabeled("WorkTab.VerticalLabels".Translate(), ref verticalLabelsBuffer,
                                      "WorkTab.VerticalLabelsTip".Translate());
@@ -87,6 +90,7 @@ namespace WorkTab {
             Scribe_Values.Look(ref playCrunch, "PlayCrunch", true);
             Scribe_Values.Look(ref disableScrollwheel, "DisableScrollwheel");
             Scribe_Values.Look(ref verticalLabels, "VerticalLabels", true);
+            Scribe_Values.Look(ref highlightActiveWorkCells, "HighlightActiveWorkCells");
             Scribe_Values.Look(ref _fontFix, "FontFix", true);
 
             // apply font-fix on load

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -6,15 +6,15 @@ using Verse;
 
 namespace WorkTab {
     public class Settings: ModSettings {
-        public static  int    defaultPriority = 3;
-        public static  bool   disableScrollwheel;
-        public static  bool   jobTextMode            = false;
-        public static  int    maxPriority            = 9;
-        public static  bool   playCrunch             = true;
-        public static  bool   playSounds             = true;
-        public static  bool   TwentyFourHourMode     = true;
-        public static  bool   verticalLabels         = true;
-        public static  bool   highlightActiveWorkCells;
+        public static int  maxPriority             = 9;
+        public static int  defaultPriority         = 3;
+        public static bool TwentyFourHourMode      = true;
+        public static bool playSounds              = true;
+        public static bool playCrunch              = true;
+        public static bool disableScrollwheel      = false;
+        public static bool jobTextMode             = false;
+        public static bool highlightCurrentJobCell = true;
+        public static bool verticalLabels          = true;
         private static string _defaultPriorityBuffer = defaultPriority.ToString();
 
         // public static bool sharedFavourites = true;
@@ -55,8 +55,8 @@ namespace WorkTab {
                                      "WorkTab.DisableScrollwheelTip".Translate());
             options.CheckboxLabeled("WorkTab.JobTextMode".Translate(), ref jobTextMode,
                                      "WorkTab.JobTextModeTip".Translate());
-            options.CheckboxLabeled("WorkTab.HighlightActiveWorkCells".Translate(), ref highlightActiveWorkCells,
-                                     "WorkTab.HighlightActiveWorkCellsTip".Translate());
+            options.CheckboxLabeled("WorkTab.HighlightCurrentJobCell".Translate(), ref highlightCurrentJobCell,
+                                     "WorkTab.HighlightCurrentJobCellTip".Translate());
             bool verticalLabelsBuffer = verticalLabels;
             options.CheckboxLabeled("WorkTab.VerticalLabels".Translate(), ref verticalLabelsBuffer,
                                      "WorkTab.VerticalLabelsTip".Translate());
@@ -70,7 +70,7 @@ namespace WorkTab {
             options.CheckboxLabeled("WorkTab.FontFix".Translate(), ref _fontFixBuffer,
                                      "WorkTab.FontFixTip".Translate());
             _fontFixBuffer =
-                verticalLabels && _fontFixBuffer; // disabling vertical labels makes the font fix unnecesary.
+                verticalLabels && _fontFixBuffer; // disabling vertical labels makes the font fix unnecessary.
 
             // apply any changes.
             if (_fontFixBuffer != _fontFix) {
@@ -94,7 +94,7 @@ namespace WorkTab {
             Scribe_Values.Look(ref disableScrollwheel, "DisableScrollwheel");
             Scribe_Values.Look(ref jobTextMode, "JobTextMode");
             Scribe_Values.Look(ref verticalLabels, "VerticalLabels", true);
-            Scribe_Values.Look(ref highlightActiveWorkCells, "HighlightActiveWorkCells");
+            Scribe_Values.Look(ref highlightCurrentJobCell, "HighlightCurrentJobCell", true);
             Scribe_Values.Look(ref _fontFix, "FontFix", true);
 
             // apply font-fix on load

--- a/Source/Core/Settings.cs
+++ b/Source/Core/Settings.cs
@@ -1,4 +1,4 @@
-// Settings.cs
+﻿// Settings.cs
 // Copyright Karel Kroeze, 2020-2020
 
 using UnityEngine;
@@ -18,6 +18,11 @@ namespace WorkTab {
         private static bool _fontFix = true;
         // public static bool sharedFavourites = true;
 
+        // Buffers will be initialized with current settings as soon as
+        // DoWindowContents() → Listing_Standard.TextFieldNumericLabeled() → Widgets.TextFieldNumeric() will be called.
+        private static string maxPriorityBuffer = null;
+        private static string defaultPriorityBuffer = null;
+
         public Settings() {
             ApplyFontFix(_fontFix);
         }
@@ -34,10 +39,8 @@ namespace WorkTab {
         public static void DoWindowContents(Rect rect) {
             Listing_Standard options = new Listing_Standard();
             options.Begin(rect);
-            string maxPriorityBuffer = null;
             options.TextFieldNumericLabeled("WorkTab.MaxPriority".Translate(), ref maxPriority, ref maxPriorityBuffer,
                                              4, 9, "WorkTab.MaxPriorityTip".Translate(), 1 / 8f);
-            string defaultPriorityBuffer = null;
             options.TextFieldNumericLabeled("WorkTab.DefaultPriority".Translate(), ref defaultPriority,
                                              ref defaultPriorityBuffer, 1, 9, "WorkTab.DefaultPriorityTip".Translate(),
                                              1 / 8f);

--- a/Source/Extensions/PawnTable_Extensions.cs
+++ b/Source/Extensions/PawnTable_Extensions.cs
@@ -1,0 +1,35 @@
+﻿using RimWorld;
+using RimWorld.BaseGen;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace WorkTab.Extensions {
+    internal static class PawnTable_Extensions {
+        private static ConditionalWeakTable<PawnTable, StrongBox<Rect>> outRectDictionary=new ConditionalWeakTable<PawnTable, StrongBox<Rect>>();
+        /// <summary>
+        /// Sets the rectangle the <see cref="PawnTable"/> is drawn in.
+        /// </summary>
+        /// <param name="pawnTable">The <see cref="PawnTable"/> being extended.</param>
+        /// <param name="outRect">The rectangle the <see cref="PawnTable"/> will be drawn in.</param>
+        internal static void set_OutRect(this PawnTable pawnTable, Rect outRect) {
+            var value = outRectDictionary.GetValue(
+                pawnTable,
+                a => new StrongBox<Rect>(outRect)
+            );
+            value.Value = outRect;
+        }
+        /// <summary>
+        /// Gets the rectangle the <see cref="PawnTable"/> will be drawn in.
+        /// </summary>
+        /// <param name="pawnTable">The <see cref="PawnTable"/> being extended.</param>
+        /// <returns>The rectangle the <see cref="PawnTable"/> will be drawn in.</returns>
+        internal static Rect get_OutRect(this PawnTable pawnTable) {
+            return outRectDictionary.GetOrCreateValue(pawnTable).Value;
+        }
+    }
+}

--- a/Source/Favourites/FavouriteManager.cs
+++ b/Source/Favourites/FavouriteManager.cs
@@ -179,7 +179,7 @@ namespace WorkTab
                                    .ToList();
             if (options.Count == 0)
             {
-                options.Add(new FloatMenuOption("Fluffy.WorkTab.NoStoredFavourites", null));
+                options.Add(new FloatMenuOption("Fluffy.WorkTab.NoStoredFavourites".Translate(), null));
             }
             Find.WindowStack.Add(new FloatMenu(options));
         }

--- a/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
+++ b/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
@@ -24,7 +24,7 @@ namespace WorkTab {
             // insert mood and job columns before first work column name
             int firstWorkindex =
                 workTable.columns.FindIndex(d => d.workerClass == typeof(PawnColumnWorker_WorkPriority));
-            if (true) {
+            if (Settings.jobTextMode) {
                 workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.JobText);
             } else {
                 workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.Job);

--- a/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
+++ b/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
@@ -24,7 +24,11 @@ namespace WorkTab {
             // insert mood and job columns before first work column name
             int firstWorkindex =
                 workTable.columns.FindIndex(d => d.workerClass == typeof(PawnColumnWorker_WorkPriority));
-            workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.Job);
+            if (true) {
+                workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.JobText);
+            } else {
+                workTable.columns.Insert(firstWorkindex, PawnColumnDefOf.Job);
+            }
             workTable.columns.Insert(firstWorkindex + 1, PawnColumnDefOf.Mood);
 
             // go over PawnColumnDefs and replace all PawnColumnWorker_WorkPriority

--- a/Source/HarmonyPatches/PawnTable/PawnTable_PawnTableOnGUI.cs
+++ b/Source/HarmonyPatches/PawnTable/PawnTable_PawnTableOnGUI.cs
@@ -8,6 +8,7 @@ using HarmonyLib;
 using RimWorld;
 using UnityEngine;
 using Verse;
+using WorkTab.Extensions;
 
 namespace WorkTab {
     [HarmonyPatch(typeof(PawnTable), nameof(PawnTable.PawnTableOnGUI))]
@@ -79,7 +80,11 @@ namespace WorkTab {
             // Instead, we want to limit outRect to the available view area, so a horizontal scrollbar can appear.
             float labelWidth = cachedColumnWidths[0];
             var labelCol   = columns[0];
-            float outWidth   = Mathf.Min( cachedSize.x - labelWidth, UI.screenWidth - (standardWindowMargin * 2f) );
+            // ideally this method would be called with a Rect outRect
+            // indicating the window it is being drawn in instead
+            // of a Vector2 position
+            var outRect = __instance.get_OutRect();
+            float outWidth   = outRect.width - labelWidth;
             float viewWidth  = cachedSize.x - labelWidth - 16f;
 
             Rect labelHeaderRect = new Rect(

--- a/Source/PawnColumns/PawnColumnWorker_JobText.cs
+++ b/Source/PawnColumns/PawnColumnWorker_JobText.cs
@@ -1,0 +1,33 @@
+// Copyright Karel Kroeze, 2020-2021.
+// WorkTab/WorkTab/PawnColumnWorker_WorkTabLabel.cs
+
+using RimWorld;
+using Verse;
+using static WorkTab.Constants;
+
+namespace WorkTab {
+    public class PawnColumnWorker_JobText : PawnColumnWorker_Text {
+        public override int GetMinWidth(PawnTable table)
+        {
+            return JobTextWidth;
+        }
+        private string GetJobString(Pawn pawn)
+        {
+            return pawn.jobs?.curDriver?.GetReport() ?? "";
+        }
+        protected override string GetTextFor(Pawn pawn) {
+            return GetJobString(pawn);
+        }
+        protected override string GetTip(Pawn pawn) {
+            return GetJobString(pawn);
+        }
+        public string GetValueToCompare(Pawn pawn)
+        {
+            return GetJobString(pawn);
+        }
+        public override int Compare(Pawn a, Pawn b)
+        {
+            return GetValueToCompare(a).CompareTo(GetValueToCompare(b));
+        }
+    }
+}

--- a/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
@@ -57,6 +57,16 @@ namespace WorkTab {
 
             WorkGiverDef workgiver = WorkGiver;
 
+            if (Settings.highlightActiveWorkCells)
+            {
+                bool doingNow = (pawn.CurJob?.workGiverDef?.defName == workgiver?.defName);
+                if (doingNow)
+                {
+                    GUI.color = Color.white;
+                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.getActiveHighlightBox());
+                }
+            }
+
             // create rect in centre of cell, slightly offsetting left to give the appearance of aligning to worktype.
             Vector2 pos = rect.center - (new Vector2( WorkGiverBoxSize, WorkGiverBoxSize ) / 2f);
             Rect box = new Rect( pos.x - 2f, pos.y, WorkGiverBoxSize, WorkGiverBoxSize );

--- a/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
@@ -63,7 +63,7 @@ namespace WorkTab {
                 if (doingNow)
                 {
                     GUI.color = Color.white;
-                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.getActiveHighlightBox());
+                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.GetActiveHighlightBox());
                 }
             }
 

--- a/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkGiver.cs
@@ -57,13 +57,13 @@ namespace WorkTab {
 
             WorkGiverDef workgiver = WorkGiver;
 
-            if (Settings.highlightActiveWorkCells)
+            if (Settings.highlightCurrentJobCell)
             {
                 bool doingNow = (pawn.CurJob?.workGiverDef?.defName == workgiver?.defName);
                 if (doingNow)
                 {
                     GUI.color = Color.white;
-                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.GetActiveHighlightBox());
+                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.GetCurrentJobHighlightBox());
                 }
             }
 

--- a/Source/PawnColumns/PawnColumnWorker_WorkType.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkType.cs
@@ -82,13 +82,13 @@ namespace WorkTab {
             bool incapable = IncapableOfWholeWorkType( pawn );
             WorkTypeDef worktype  = def.workType;
 
-            if (Settings.highlightActiveWorkCells)
+            if (Settings.highlightCurrentJobCell)
             {
                 bool doingNow = (pawn.CurJob?.workGiverDef?.workType?.defName == worktype?.defName);
                 if (doingNow)
                 {
                     GUI.color = Color.white;
-                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.GetActiveHighlightBox());
+                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.GetCurrentJobHighlightBox());
                 }
             }
 

--- a/Source/PawnColumns/PawnColumnWorker_WorkType.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkType.cs
@@ -82,6 +82,16 @@ namespace WorkTab {
             bool incapable = IncapableOfWholeWorkType( pawn );
             WorkTypeDef worktype  = def.workType;
 
+            if (Settings.highlightActiveWorkCells)
+            {
+                bool doingNow = (pawn.CurJob?.workGiverDef?.workType?.defName == worktype?.defName);
+                if (doingNow)
+                {
+                    GUI.color = Color.white;
+                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.getActiveHighlightBox());
+                }
+            }
+
             // create rect in centre of cell
             Vector2 pos = rect.center - (new Vector2( WorkTypeBoxSize, WorkTypeBoxSize ) / 2f);
             Rect box = new Rect( pos.x, pos.y, WorkTypeBoxSize, WorkTypeBoxSize );

--- a/Source/PawnColumns/PawnColumnWorker_WorkType.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkType.cs
@@ -381,7 +381,7 @@ namespace WorkTab {
         }
 
         private void HandleInteractionsToggle(Rect rect, Pawn pawn) {
-            if ((Event.current.type == EventType.MouseDown || Event.current.type == EventType.ScrollWheel)
+            if ((Event.current.type == EventType.MouseDown || (Event.current.type == EventType.ScrollWheel && !Settings.disableScrollwheel))
               && Mouse.IsOver(rect)) {
                 // track priority so we can play appropriate sounds
                 bool active = pawn.GetPriority( def.workType, VisibleHour ) > 0;

--- a/Source/PawnColumns/PawnColumnWorker_WorkType.cs
+++ b/Source/PawnColumns/PawnColumnWorker_WorkType.cs
@@ -88,7 +88,7 @@ namespace WorkTab {
                 if (doingNow)
                 {
                     GUI.color = Color.white;
-                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.getActiveHighlightBox());
+                    GUI.DrawTexture(rect.ContractedBy(-2f), DrawUtilities.GetActiveHighlightBox());
                 }
             }
 

--- a/Source/PawnTable/MainTabWindow_WorkTab.cs
+++ b/Source/PawnTable/MainTabWindow_WorkTab.cs
@@ -10,6 +10,7 @@ using RimWorld;
 using RimWorld.Planet;
 using UnityEngine;
 using Verse;
+using WorkTab.Extensions;
 using static WorkTab.Constants;
 using static WorkTab.InteractionUtilities;
 using static WorkTab.Resources;
@@ -122,6 +123,7 @@ namespace WorkTab {
         }
 
         public override void DoWindowContents(Rect rect) {
+            Instance.Table.set_OutRect(rect);
             if (_columnsChanged) {
                 RebuildTable();
             }

--- a/Source/Priorities/PriorityManager.cs
+++ b/Source/Priorities/PriorityManager.cs
@@ -16,11 +16,15 @@ namespace WorkTab {
         private        List<PawnPriorityTracker>             pawnPriorityTrackersScribe;
         private        List<Pawn>                            pawnsScribe;
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "RimWorld requires a constructor with parameter")]
         public PriorityManager(Game game) : this() {
         }
 
         public PriorityManager() {
             _instance = this;
+            _nextId = 0;
+            _showScheduler = false;
+            priorities = new Dictionary<Pawn, PawnPriorityTracker>();
         }
 
         public static PriorityManager Get {
@@ -90,7 +94,7 @@ namespace WorkTab {
             List<Pawn> pawns = priorities.Keys.ToList();
             foreach (Pawn pawn in pawns) {
                 if (pawn?.Destroyed ?? true) // null or destroyed
-{
+                {
                     priorities.Remove(pawn);
                 }
             }

--- a/Source/Utilities/DefOf.cs
+++ b/Source/Utilities/DefOf.cs
@@ -14,6 +14,7 @@ namespace WorkTab {
         [MayRequireIdeology] public static PawnColumnDef Guest;
         [MayRequireIdeology] public static PawnColumnDef Ideo;
         public static                      PawnColumnDef Job;
+        public static                      PawnColumnDef JobText;
         public static                      PawnColumnDef LabelShortWithIcon;
         public static                      PawnColumnDef Mood;
         public static                      PawnColumnDef WorkTabLabel;

--- a/Source/Utilities/DrawUtilities.cs
+++ b/Source/Utilities/DrawUtilities.cs
@@ -72,7 +72,7 @@ namespace WorkTab {
         }
 
         private static Texture2D activeHighlightBox;
-        public static Texture2D getActiveHighlightBox()
+        public static Texture2D GetActiveHighlightBox()
         {
             if (activeHighlightBox != null)
             {

--- a/Source/Utilities/DrawUtilities.cs
+++ b/Source/Utilities/DrawUtilities.cs
@@ -70,6 +70,25 @@ namespace WorkTab {
             _drawWorkBoxBackgroundMethodInfo.Invoke(null, new object[] { box, pawn, worktype });
         }
 
+        private static Texture2D activeHighlightBox;
+        public static Texture2D getActiveHighlightBox()
+        {
+            if (activeHighlightBox != null)
+            {
+                return activeHighlightBox;
+            }
+            Color color = Color.magenta;
+            Texture2D startingExample = WidgetsWork.WorkBoxOverlay_PreceptWarning;
+            int width = startingExample.width;
+            int height = startingExample.height;
+            Texture2D texture = new Texture2D(width, height);
+            Color[] pixels = Enumerable.Repeat(color, width * height).ToArray();
+            texture.SetPixels(pixels);
+            texture.Apply();
+            activeHighlightBox = texture;
+            return activeHighlightBox;
+        }
+
         public static string PriorityLabel(int priority) {
             /**
              *                  9   8   7   6   5   4

--- a/Source/Utilities/DrawUtilities.cs
+++ b/Source/Utilities/DrawUtilities.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 using Verse;
 
 namespace WorkTab {
+    [StaticConstructorOnStartup]
     public static class DrawUtilities {
         private static MethodInfo _drawWorkBoxBackgroundMethodInfo;
 

--- a/Source/Utilities/DrawUtilities.cs
+++ b/Source/Utilities/DrawUtilities.cs
@@ -78,7 +78,7 @@ namespace WorkTab {
             {
                 return activeHighlightBox;
             }
-            Color color = Color.magenta;
+            Color color = Color.Lerp(Color.black, Color.magenta, 0.7f);
             Texture2D startingExample = WidgetsWork.WorkBoxOverlay_PreceptWarning;
             int width = startingExample.width;
             int height = startingExample.height;

--- a/Source/Utilities/DrawUtilities.cs
+++ b/Source/Utilities/DrawUtilities.cs
@@ -71,12 +71,12 @@ namespace WorkTab {
             _drawWorkBoxBackgroundMethodInfo.Invoke(null, new object[] { box, pawn, worktype });
         }
 
-        private static Texture2D activeHighlightBox;
-        public static Texture2D GetActiveHighlightBox()
+        private static Texture2D currentJobHighlightBox;
+        public static Texture2D GetCurrentJobHighlightBox()
         {
-            if (activeHighlightBox != null)
+            if (currentJobHighlightBox != null)
             {
-                return activeHighlightBox;
+                return currentJobHighlightBox;
             }
             Color color = Color.Lerp(Color.black, Color.magenta, 0.7f);
             Texture2D startingExample = WidgetsWork.WorkBoxOverlay_PreceptWarning;
@@ -86,8 +86,8 @@ namespace WorkTab {
             Color[] pixels = Enumerable.Repeat(color, width * height).ToArray();
             texture.SetPixels(pixels);
             texture.Apply();
-            activeHighlightBox = texture;
-            return activeHighlightBox;
+            currentJobHighlightBox = texture;
+            return currentJobHighlightBox;
         }
 
         public static string PriorityLabel(int priority) {

--- a/Source/WorkTab.sln
+++ b/Source/WorkTab.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 15.0.26430.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WorkTab", "WorkTab.csproj", "{5C909B0F-E82A-46B1-AE39-E56285B236A2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicPawnTable", "..\..\..\TOOLS\DynamicPawnTable\DynamicPawnTable\DynamicPawnTable.csproj", "{E93B85A6-EEFF-4BDE-A6F4-CCE6D3487F9A}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluffyUI", "..\..\..\TOOLS\FluffyUI\FluffyUI\FluffyUI.csproj", "{3E905175-2540-4C06-B4C6-F955836C0451}"
 EndProject
 Global
@@ -19,10 +17,6 @@ Global
 		{5C909B0F-E82A-46B1-AE39-E56285B236A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C909B0F-E82A-46B1-AE39-E56285B236A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C909B0F-E82A-46B1-AE39-E56285B236A2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E93B85A6-EEFF-4BDE-A6F4-CCE6D3487F9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E93B85A6-EEFF-4BDE-A6F4-CCE6D3487F9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E93B85A6-EEFF-4BDE-A6F4-CCE6D3487F9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E93B85A6-EEFF-4BDE-A6F4-CCE6D3487F9A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3E905175-2540-4C06-B4C6-F955836C0451}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3E905175-2540-4C06-B4C6-F955836C0451}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E905175-2540-4C06-B4C6-F955836C0451}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Fix the following scenario:

1. Save a game without the mod active.
2. Activate the mod.
3. Load the game twice.
4. Change work priorities.
5. Save.
6. Load.
7. Priorities are reset to default values and there are errors in the log:\
**Exception in LookDictionary(label=Priorities): System.InvalidOperationException: Tried to add different values for the same key.**

Also, fix the following scenario:

1. Play any game with the mod active.
2. Start a new game (without exiting the application).
3. Save.
4. Load.
5. Probably harmless errors appear in the log:\
**Could not resolve reference to object with loadID Thing_Human#**

Supposedly, fixes fluffy-mods/WorkTab#203 and fixes fluffy-mods/WorkTab#208.

Games saved with the erroneous mod version may still give errors on load. Saving them anew should fix them.

Too bad, the source branch of this pull request was updated, and while the PR was supposed to be just one commit, now it's not. PR https://github.com/fluffy-mods/WorkTab/pull/210 supersedes this one.

EDIT: This pull request is closed after I updated it's source branch. The PR was supposed to have just one [commit](https://github.com/fluffy-mods/WorkTab/pull/209/commits/c2b1a428de3934c2bc3264fa3a0042eeee3982d8), but now it pulls too much. PR fluffy-mods/WorkTab#210 supersedes this one.
