### PR TITLE
1.5 Update Fixes

### DIFF
--- a/Source/Extensions/Job_Extensions.cs
+++ b/Source/Extensions/Job_Extensions.cs
@@ -157,7 +157,7 @@ namespace WorkTab {
             }
 
             // social
-            if (job == JobDefOf.SocialRelax ||
+            if (//job == JobDefOf.SocialRelax || // Missing in 1.5
                 job == JobDefOf.SpectateCeremony ||
                 job == JobDefOf.StandAndBeSociallyActive ||
                 job == JobDefOf.Insult ||
@@ -265,7 +265,7 @@ namespace WorkTab {
             if (job == JobDefOf.Open ||
                 job == JobDefOf.EnterCryptosleepCasket ||
                 job == JobDefOf.UseNeurotrainer ||
-                job == JobDefOf.UseArtifact ||
+                //job == JobDefOf.UseArtifact || // Missing in 1.5
                 job == JobDefOf.Flick ||
                 job == JobDefOf.EnterTransporter ||
                 job == JobDefOf2.UseItem ||

--- a/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
+++ b/Source/HarmonyPatches/DefGenerator_GenerateImpliedDefs_PreResolve.cs
@@ -18,8 +18,18 @@ namespace WorkTab {
 
             // replace label column
             int labelIndex = workTable.columns.IndexOf(PawnColumnDefOf.LabelShortWithIcon);
-            workTable.columns.RemoveAt(labelIndex);
-            workTable.columns.Insert(labelIndex, PawnColumnDefOf.WorkTabLabel);
+            // Fix for 1.5 returning invalid index
+            if (labelIndex != -1)
+            {
+                workTable.columns.RemoveAt(labelIndex);
+                workTable.columns.Insert(labelIndex, PawnColumnDefOf.WorkTabLabel);
+            }
+            else
+            {
+                //Logger.Debug($"Invalid work table index for {PawnColumnDefOf.LabelShortWithIcon.LabelCap}.");
+                workTable.columns.RemoveAt(0);
+                workTable.columns.Insert(0, PawnColumnDefOf.WorkTabLabel);
+            }
 
             // insert mood and job columns before first work column name
             int firstWorkindex =

--- a/Source/WorkTab.csproj
+++ b/Source/WorkTab.csproj
@@ -24,8 +24,8 @@
     <ProjectReference Include="..\..\..\TOOLS\FluffyUI\FluffyUI\FluffyUI.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3517-beta" />
-    <PackageReference Include="Lib.Harmony" Version="2.1.1" ExcludeAssets="runtime" />
-    <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.3.0" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4034-beta" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.1.1" ExcludeAssets="runtime" />
+    <PackageReference Include="RimWorld.MultiplayerAPI" Version="0.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates assembles to support newest and fixes two simple issues causing build or run failures:

1. Two missing work types in the icon assignments
2. Negative index issue on startup when trying to replace LabelShortWithIcon in the Harmony patch. Forcing use of 0 is working, and I wrapped it in a catch statement in case this is a bug on Ludeon's part that is later resolved and the index moves back to a valid number.